### PR TITLE
Update wifi_config_log_handle.c

### DIFF
--- a/qcloud-iot-esp8266-demo/main/wifi_config/wifi_config_log_handle.c
+++ b/qcloud-iot-esp8266-demo/main/wifi_config/wifi_config_log_handle.c
@@ -28,10 +28,12 @@
 
 /************** WiFi config error msg collect and post feature ******************/
 
+#ifdef WIFI_LOG_UPLOAD
 /* FreeRTOS msg queue */
 static void *g_dev_log_queue = NULL;
 #define LOG_QUEUE_SIZE 10
 #define LOG_ITEM_SIZE  128
+#endif
 
 int init_dev_log_queue(void)
 {


### PR DESCRIPTION
如果不使用WIFI_LOG_UPLOAD的话，编译器会提示警告g_dev_log_queue定义了但是未使用，为了消除此警告，建议这里这样修改